### PR TITLE
Looks like CleanHyphen is undefined and can be replaced FormatCanonical

### DIFF
--- a/api/labels.go
+++ b/api/labels.go
@@ -20,7 +20,7 @@ func addLabel(name string) (*Label, error) {
 	token := savedToken.Token
 
 	// Generate some UUID to avoid duplicates
-	uuid.SwitchFormat(uuid.CleanHyphen)
+	uuid.SwitchFormat(uuid.FormatCanonical)
 	generatedUUID := uuid.NewV4().String()
 	tmpID := uuid.NewV4().String()
 

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -26,7 +26,7 @@ func AddTask(taskContent string, projectOrder int, date string, rawLabels string
 	check(err)
 
 	// Generate some UUID to avoid duplicates
-	uuid.SwitchFormat(uuid.CleanHyphen)
+	uuid.SwitchFormat(uuid.FormatCanonical)
 	generatedUUID := uuid.NewV4().String()
 	tmpID := uuid.NewV4().String()
 


### PR DESCRIPTION
It's pretty much guess work here, I'm no Go expert, but it did the trick for me to recompile on OS X